### PR TITLE
Add expanded test coverage

### DIFF
--- a/test/openai.test.js
+++ b/test/openai.test.js
@@ -1,0 +1,43 @@
+import nock from "nock";
+import { fetchOpenAIReview } from "../src/services/openai.js";
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+
+describe("fetchOpenAIReview", () => {
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  test("returns review content from OpenAI", async () => {
+    const mock = nock("https://api.openai.com")
+      .post("/v1/chat/completions")
+      .reply(200, {
+        choices: [
+          {
+            message: { content: "review" },
+          },
+        ],
+      });
+
+    const result = await fetchOpenAIReview("diff", "key");
+    assert.equal(result, "review");
+    assert.deepStrictEqual(mock.pendingMocks(), []);
+  });
+
+  test("throws when OpenAI returns an error", async () => {
+    const mock = nock("https://api.openai.com")
+      .post("/v1/chat/completions")
+      .reply(500, "oops");
+
+    await assert.rejects(
+      fetchOpenAIReview("diff", "key"),
+      /OpenAI request failed: 500/
+    );
+    assert.deepStrictEqual(mock.pendingMocks(), []);
+  });
+});

--- a/test/pull_request.test.js
+++ b/test/pull_request.test.js
@@ -1,0 +1,86 @@
+import nock from "nock";
+import myProbotApp from "../index.js";
+import { Probot, ProbotOctokit } from "probot";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, beforeEach, afterEach, test } from "node:test";
+import assert from "node:assert";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const privateKey = fs.readFileSync(
+  path.join(__dirname, "fixtures/mock-cert.pem"),
+  "utf-8",
+);
+
+const prPayload = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "fixtures/pull_request.opened.json"), "utf-8"),
+);
+const prPayloadOriginal = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "fixtures/pull_request.opened.json"), "utf-8"),
+);
+
+describe("Pull request handler", () => {
+  let probot;
+
+  beforeEach(() => {
+    nock.disableNetConnect();
+    probot = new Probot({
+      appId: 123,
+      privateKey,
+      Octokit: ProbotOctokit.defaults({
+        retry: { enabled: false },
+        throttle: { enabled: false },
+      }),
+    });
+    probot.load(myProbotApp);
+  });
+
+  test("skips when OPENAI_API_KEY is not set", async () => {
+    await probot.receive({ name: "pull_request", payload: prPayload });
+  });
+
+  test("posts fallback comment when OpenAI response is invalid JSON", async () => {
+    process.env.OPENAI_API_KEY = "test";
+
+    const ghMock = nock("https://api.github.com")
+      .post("/app/installations/2/access_tokens")
+      .reply(200, {
+        token: "test",
+        permissions: {
+          issues: "write",
+          pull_requests: "read",
+        },
+      })
+      .get("/repos/hiimbex/testing-things/pulls/1")
+      .reply(200, "diff")
+      .post("/repos/hiimbex/testing-things/issues/1/comments", (body) => {
+        assert.deepEqual(body, { body: "invalid" });
+        return true;
+      })
+      .reply(200);
+
+    const aiMock = nock("https://api.openai.com")
+      .post("/v1/chat/completions")
+      .reply(200, {
+        choices: [
+          {
+            message: { content: "invalid" },
+          },
+        ],
+      });
+
+    await probot.receive({ name: "pull_request", payload: prPayload });
+
+    assert.deepStrictEqual(ghMock.pendingMocks(), []);
+    assert.deepStrictEqual(aiMock.pendingMocks(), []);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+    delete process.env.OPENAI_API_KEY;
+    Object.assign(prPayload, prPayloadOriginal);
+  });
+});


### PR DESCRIPTION
## Summary
- test OpenAI service directly
- add pull request handler edge case tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68535b00955c8327999ecc10dbfc5efc